### PR TITLE
Update Ec2 instance module v2

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -34,7 +34,7 @@ data "template_file" "userdata" {
 
 module "ec2_instance" {
   source  = "cloudposse/ec2-instance/aws"
-  version = "1.4.0"
+  version = "2.0.0"
 
   enabled = local.enabled
 


### PR DESCRIPTION
## what
* Update Ubuntu AMI query
* Fix enabled flag

## why
* AMI 18.04 is deprecated
* Not all resources used to support the enabled flag

## references
* https://github.com/cloudposse/terraform-aws-ec2-instance/pull/215


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the EC2 instance module to a newer version for improved compatibility and features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->